### PR TITLE
Now we can see which unit is under mouse.

### DIFF
--- a/Open-Rival/include/MousePicker.h
+++ b/Open-Rival/include/MousePicker.h
@@ -1,6 +1,8 @@
 #ifndef MOUSE_PICKER_H
 #define MOUSE_PICKER_H
 
+#include <memory>
+
 #include "Camera.h"
 
 namespace Rival {
@@ -9,7 +11,7 @@ namespace Rival {
 
     public:
 
-        MousePicker(Camera& camera, int mapWidth, int mapHeight);
+        MousePicker(Camera& camera, std::shared_ptr<Scenario> scenario);
 
         void handleMouse();
 
@@ -17,6 +19,7 @@ namespace Rival {
 
         int getTileY() const;
 
+        int getEntity() const;
     private:
 
         Camera& camera;
@@ -29,6 +32,9 @@ namespace Rival {
 
         int tileY;
 
+        int entity;
+
+        std::shared_ptr<Scenario> scenario;
     };
 
 }

--- a/Open-Rival/include/Rival.h
+++ b/Open-Rival/include/Rival.h
@@ -63,7 +63,7 @@ namespace Rival {
         std::unique_ptr<Framebuffer> gameFbo;
 
         // Scenario
-        std::unique_ptr<Scenario> scenario;
+        std::shared_ptr<Scenario> scenario;
 
         // Renderers
         std::unique_ptr<FramebufferRenderer> gameFboRenderer;

--- a/Open-Rival/include/ScenarioBuilder.h
+++ b/Open-Rival/include/ScenarioBuilder.h
@@ -17,7 +17,7 @@ namespace Rival {
 
         ScenarioBuilder(ScenarioData data);
 
-        std::unique_ptr<Scenario> build();
+        std::shared_ptr<Scenario> build();
 
     private:
 

--- a/Open-Rival/include/Unit.h
+++ b/Open-Rival/include/Unit.h
@@ -109,6 +109,7 @@ namespace Rival {
 
         int getY() const;
 
+        /// \todo getPos(), with std::atomic<std::pair<int, int>> pos instead of int x, int y would prevent race conditions
     private:
 
         int id = -1;

--- a/Open-Rival/src/MousePicker.cpp
+++ b/Open-Rival/src/MousePicker.cpp
@@ -10,11 +10,12 @@ namespace Rival {
 
     MousePicker::MousePicker(
             Camera& camera,
-            int mapWidth,
-            int mapHeight) :
+            std::shared_ptr<Scenario> scenario) :
         camera(camera),
-        mapWidth(mapWidth),
-        mapHeight(mapHeight) {}
+        scenario(scenario),
+        mapWidth(scenario->getWidth()),
+        mapHeight(scenario->getHeight()),
+        entity(-1) {}
 
     void MousePicker::handleMouse() {
 
@@ -120,6 +121,22 @@ namespace Rival {
         // but we should limit them to the level bounds
         tileX = MathUtils::clampi(tileX, 0, mapWidth - 1);
         tileY = MathUtils::clampi(tileY, 0, mapHeight - 1);
+
+        if ( scenario ) {
+            auto& units = scenario->getUnits();
+            bool foundEntity = false;
+            for ( auto it = units.begin(); it != units.end(); ++it ) {
+                if ( it->second->getX() == tileX && it->second->getY() == tileY ) {
+                    entity = it->second->getId();
+                    std::cout << "Entity " << entity << " is under cursor.\n";
+                    foundEntity = true;
+                    break;
+                }
+            }
+            if ( !foundEntity ) {
+                entity = -1;
+            }
+        }
     }
 
     int MousePicker::getTileX() const {
@@ -130,4 +147,7 @@ namespace Rival {
         return tileY;
     }
 
+    int MousePicker::getEntity() const {
+        return entity;
+    }
 }

--- a/Open-Rival/src/Rival.cpp
+++ b/Open-Rival/src/Rival.cpp
@@ -61,10 +61,7 @@ namespace Rival {
                 0.0f, 0.0f, cameraWidth, aspectRatio, *scenario);
 
         // Create the MousePicker
-        mousePicker = std::make_unique<MousePicker>(
-                *camera,
-                scenario->getWidth(),
-                scenario->getHeight());
+        mousePicker = std::make_unique<MousePicker>(*camera, scenario);
 
         // Pick which tile Spritesheet to use based on the map type
         const Spritesheet& tileSpritesheet = scenario->isWilderness()

--- a/Open-Rival/src/Scenario.cpp
+++ b/Open-Rival/src/Scenario.cpp
@@ -14,7 +14,8 @@ namespace Rival {
             ),
             tilePassability(std::vector<TilePassability>(
                     width * height, TilePassability::Clear)
-            ) {}
+            ),
+            nextId(0) {}
 
     int Scenario::getWidth() const {
         return width;

--- a/Open-Rival/src/ScenarioBuilder.cpp
+++ b/Open-Rival/src/ScenarioBuilder.cpp
@@ -10,9 +10,9 @@ namespace Rival {
     ScenarioBuilder::ScenarioBuilder(ScenarioData data) :
         data(data) {}
 
-    std::unique_ptr<Scenario> ScenarioBuilder::build() {
+    std::shared_ptr<Scenario> ScenarioBuilder::build() {
 
-        std::unique_ptr<Scenario> scenario = std::make_unique<Scenario>(
+        std::shared_ptr<Scenario> scenario = std::make_shared<Scenario>(
                 data.hdr.mapWidth,
                 data.hdr.mapHeight,
                 data.hdr.wilderness);


### PR DESCRIPTION
MousePicker has access to Scenario, adding similar checks to buildings, terrain etc should be trivial.