### PR TITLE
Temporary fix for MapBorderRenderer

### DIFF
--- a/Open-Rival/Open-Rival.vcxproj
+++ b/Open-Rival/Open-Rival.vcxproj
@@ -170,7 +170,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>

--- a/Open-Rival/include/MapBorderRenderer.h
+++ b/Open-Rival/include/MapBorderRenderer.h
@@ -61,14 +61,14 @@ namespace Rival {
 
         void render();
 
+    private:
+
+        const Texture& paletteTexture;
+
         // The maximum number of border segments we can render
         int maxSegmentsToRender;
 
-    private:
-
         SpriteRenderable renderable;
-
-        const Texture& paletteTexture;
 
         int numSegments = 0;
 

--- a/Open-Rival/include/MapBorderRenderer.h
+++ b/Open-Rival/include/MapBorderRenderer.h
@@ -17,11 +17,6 @@ namespace Rival {
 
     public:
 
-        // The maximum number of border segments we can render
-        static const int maxSegmentsToRender =
-                (2 * RenderUtils::maxTilesX)
-                + (2 * RenderUtils::maxTilesY);
-
         MapBorderRenderer(
                 Race race,
                 int mapWidth,
@@ -29,29 +24,29 @@ namespace Rival {
                 const Spritesheet& spritesheet,
                 const Texture& paletteTexture);
 
-        void MapBorderRenderer::createLeftEdge(
+        void createLeftEdge(
                 std::vector<GLfloat>& positions,
                 std::vector<GLfloat>& texCoords,
                 int mapHeight);
 
-        void MapBorderRenderer::createTopEdge(
+        void createTopEdge(
                 std::vector<GLfloat>& positions,
                 std::vector<GLfloat>& texCoords,
                 int mapWidth);
 
-        void MapBorderRenderer::createRightEdge(
+        void createRightEdge(
                 std::vector<GLfloat>& positions,
                 std::vector<GLfloat>& texCoords,
                 int mapWidth,
                 int mapHeight);
 
-        void MapBorderRenderer::createBottomEdge(
+        void createBottomEdge(
                 std::vector<GLfloat>& positions,
                 std::vector<GLfloat>& texCoords,
                 int mapWidth,
                 int mapHeight);
 
-        void MapBorderRenderer::createCorners(
+        void createCorners(
                 std::vector<GLfloat>& positions,
                 std::vector<GLfloat>& texCoords,
                 int mapWidth,
@@ -65,6 +60,9 @@ namespace Rival {
                 float tileY);
 
         void render();
+
+        // The maximum number of border segments we can render
+        int maxSegmentsToRender;
 
     private:
 

--- a/Open-Rival/include/ScenarioReader.h
+++ b/Open-Rival/include/ScenarioReader.h
@@ -33,7 +33,7 @@ namespace Rival {
         std::vector<unsigned char> data;
         size_t pos = 0;
 
-        void ScenarioReader::readFileContents(const std::string filename);
+        void readFileContents(const std::string filename);
 
         ///////////////////////////////////////////////////////////////////////
         // Parsing
@@ -47,7 +47,7 @@ namespace Rival {
 
         TroopDefaults parseTroopDefaults();
 
-        bool ScenarioReader::doesUpgradeHaveAmount(int i) const;
+        bool doesUpgradeHaveAmount(int i) const;
 
         UpgradeProperties parseUpgradeProperties(bool readAmount);
 
@@ -61,10 +61,10 @@ namespace Rival {
 
         AiSetting parseAiSetting();
 
-        std::vector<TilePlacement> ScenarioReader::parseTiles(
+        std::vector<TilePlacement> parseTiles(
                 int width, int height);
 
-        TilePlacement ScenarioReader::parseTile();
+        TilePlacement parseTile();
 
         std::vector<ObjectPlacement> parseObjects();
 
@@ -146,7 +146,7 @@ namespace Rival {
         // Printing
         ///////////////////////////////////////////////////////////////////////
 
-        void ScenarioReader::printOffset() const;
+        void printOffset() const;
 
         void printSection(std::string title) const;
 

--- a/Open-Rival/include/Unit.h
+++ b/Open-Rival/include/Unit.h
@@ -18,7 +18,7 @@ namespace Rival {
 
         Unit(UnitType type);
 
-        void addedToWorld(int id, int player, int x, int y, Facing facing);
+        void addedToWorld(int newId, int newPlayer, int newX, int newY, Facing newFacing);
 
         int getCurrentSpriteIndex() const;
 
@@ -44,9 +44,9 @@ namespace Rival {
 
     private:
 
-        int id = -1;
+        int id;
 
-        bool deleted = false;
+        bool deleted;
 
         UnitType type;
 

--- a/Open-Rival/include/UnitAnimation.h
+++ b/Open-Rival/include/UnitAnimation.h
@@ -28,7 +28,7 @@ namespace Rival {
 
         int animationStep;
 
-        Facing facing = Facing::South;
+        Facing facing;
 
         SpritesheetEntry spritesheetEntry;
 

--- a/Open-Rival/include/UnitRenderer.h
+++ b/Open-Rival/include/UnitRenderer.h
@@ -31,6 +31,7 @@ namespace Rival {
                 std::map<UnitType, Spritesheet>& unitSprites,
                 Texture& paletteTexture);
 
+        UnitRenderer( const UnitRenderer& ) = delete;
         UnitRenderer& operator=(const UnitRenderer&) = delete;
 
         void render(

--- a/Open-Rival/include/UnitRenderer.h
+++ b/Open-Rival/include/UnitRenderer.h
@@ -31,6 +31,8 @@ namespace Rival {
                 std::map<UnitType, Spritesheet>& unitSprites,
                 Texture& paletteTexture);
 
+        UnitRenderer& operator=(const UnitRenderer&) = delete;
+
         void render(
                 const Camera& camera,
                 const std::map<int, std::unique_ptr<Unit>>& units);

--- a/Open-Rival/src/MapBorderRenderer.cpp
+++ b/Open-Rival/src/MapBorderRenderer.cpp
@@ -18,6 +18,7 @@ namespace Rival {
             const Spritesheet& spritesheet,
             const Texture& paletteTexture) :
         paletteTexture(paletteTexture),
+        maxSegmentsToRender(2 * (mapWidth+mapHeight) - 4),
         renderable{ spritesheet, maxSegmentsToRender } {
 
         // The map border never changes, so we set the buffers here and never
@@ -82,7 +83,7 @@ namespace Rival {
             std::vector<GLfloat>& positions,
             std::vector<GLfloat>& texCoords,
             int mapHeight) {
-        for (int tileY = 1; tileY < mapHeight; tileY++) {
+        for (int tileY = 1; tileY < mapHeight; ++tileY) {
             addDataToBuffers(positions, texCoords, 3,
                     0,
                     static_cast<float>(tileY));
@@ -94,7 +95,7 @@ namespace Rival {
             std::vector<GLfloat>& positions,
             std::vector<GLfloat>& texCoords,
             int mapWidth) {
-        for (int tileX = 1; tileX < mapWidth - 1; tileX++) {
+        for (int tileX = 1; tileX < mapWidth - 1; ++tileX) {
             addDataToBuffers(positions, texCoords, 0,
                     static_cast<float>(tileX),
                     0);
@@ -107,7 +108,7 @@ namespace Rival {
             std::vector<GLfloat>& texCoords,
             int mapWidth,
             int mapHeight) {
-        for (int tileY = 1; tileY < mapHeight; tileY++) {
+        for (int tileY = 1; tileY < mapHeight; ++tileY) {
             addDataToBuffers(positions, texCoords, 1,
                     mapWidth - 1.0f,
                     static_cast<float>(tileY));
@@ -120,7 +121,7 @@ namespace Rival {
             std::vector<GLfloat>& texCoords,
             int mapWidth,
             int mapHeight) {
-        for (int tileX = 1; tileX < mapWidth - 1; tileX++) {
+        for (int tileX = 1; tileX < mapWidth - 1; ++tileX) {
             addDataToBuffers(positions, texCoords, 2,
                     static_cast<float>(tileX),
                     mapHeight - 0.5f);

--- a/Open-Rival/src/MapBorderRenderer.cpp
+++ b/Open-Rival/src/MapBorderRenderer.cpp
@@ -18,7 +18,7 @@ namespace Rival {
             const Spritesheet& spritesheet,
             const Texture& paletteTexture) :
         paletteTexture(paletteTexture),
-        maxSegmentsToRender(2 * (mapWidth+mapHeight) - 4),
+        maxSegmentsToRender(2 * (mapWidth + mapHeight) - 4),
         renderable{ spritesheet, maxSegmentsToRender } {
 
         // The map border never changes, so we set the buffers here and never

--- a/Open-Rival/src/Rival.cpp
+++ b/Open-Rival/src/Rival.cpp
@@ -5,6 +5,7 @@
 #include <cstdlib>
 #include <chrono>
 #include <thread>
+#include <iostream>
 
 #include <gl/glew.h>
 #include <glm/vec3.hpp>
@@ -212,6 +213,7 @@ namespace Rival {
     }
 
     void Rival::update() {
+        //std::cout << "scenario -> " << scenario->getWidth() << ", " << scenario->getHeight() << std::endl;
 
         mousePicker->handleMouse();
 

--- a/Open-Rival/src/Rival.cpp
+++ b/Open-Rival/src/Rival.cpp
@@ -5,6 +5,7 @@
 #include <cstdlib>
 #include <chrono>
 #include <thread>
+// Delete <iostream> if std::cout is no longer utilised for quick-debugging
 #include <iostream>
 
 #include <gl/glew.h>

--- a/Open-Rival/src/ScenarioBuilder.cpp
+++ b/Open-Rival/src/ScenarioBuilder.cpp
@@ -21,7 +21,7 @@ namespace Rival {
         int numTiles = data.hdr.mapWidth * data.hdr.mapHeight;
         std::vector<Tile> tiles;
         tiles.reserve(numTiles);
-        for (int i = 0; i < numTiles; i++) {
+        for (int i = 0; i < numTiles; ++i) {
             tiles.push_back(buildTile(data.tiles[i]));
         }
         scenario->tilesLoaded(tiles);

--- a/Open-Rival/src/ScenarioReader.cpp
+++ b/Open-Rival/src/ScenarioReader.cpp
@@ -118,7 +118,7 @@ namespace Rival {
         std::uint8_t numLevels = readByte();
 
         // Skip entries for all scenarios before this one
-        for (int i = 0; i < levelIndex; i++) {
+        for (int i = 0; i < levelIndex; ++i) {
             skip(8, false);
         }
 
@@ -149,7 +149,7 @@ namespace Rival {
         // Parse player properties
         printSection("Parsing player properties");
         printOffset();
-        for (int i = 0; i < numPlayers; i++) {
+        for (int i = 0; i < numPlayers; ++i) {
             scenarioData.playerProperties[i] = parsePlayerProperties();
         }
         print(scenarioData.playerProperties[0]);
@@ -222,7 +222,7 @@ namespace Rival {
         // Parse troop defaults
         printSection("Parsing troop defaults");
         printOffset();
-        for (int i = 0; i < numTroops; i++) {
+        for (int i = 0; i < numTroops; ++i) {
             scenarioData.troopDefaults[i] = parseTroopDefaults();
         }
         print(scenarioData.troopDefaults[0]);
@@ -231,7 +231,7 @@ namespace Rival {
         // Parse upgrade properties
         printSection("Parsing upgrade properties");
         printOffset();
-        for (int i = 0; i < numUpgrades; i++) {
+        for (int i = 0; i < numUpgrades; ++i) {
             scenarioData.upgradeProperties[i] =
                     parseUpgradeProperties(doesUpgradeHaveAmount(i));
         }
@@ -259,7 +259,7 @@ namespace Rival {
         // Parse unit production costs
         printSection("Parsing unit production costs");
         printOffset();
-        for (int i = 0; i < numProductionCosts; i++) {
+        for (int i = 0; i < numProductionCosts; ++i) {
             scenarioData.productionCosts[i] = parseProductionCost();
         }
         print(scenarioData.productionCosts[0]);
@@ -268,7 +268,7 @@ namespace Rival {
         // Parse weapon defaults
         printSection("Parsing weapon defaults");
         printOffset();
-        for (int i = 0; i < numWeapons; i++) {
+        for (int i = 0; i < numWeapons; ++i) {
             scenarioData.weaponDefaults[i] = parseWeaponDefaults();
         }
         print(scenarioData.weaponDefaults[0]);
@@ -284,7 +284,7 @@ namespace Rival {
         // Parse monster defaults
         printSection("Parsing monster defaults");
         printOffset();
-        for (int i = 0; i < numMonsters; i++) {
+        for (int i = 0; i < numMonsters; ++i) {
             scenarioData.monsterDefaults[i] = parseTroopDefaults();
         }
         print(scenarioData.monsterDefaults[0]);
@@ -300,8 +300,8 @@ namespace Rival {
         // Parse AI building settings
         printSection("Parsing AI building settings");
         printOffset();
-        for (int i = 0; i < numBuildingsPerRace; i++) {
-            for (int j = 0; j < numAiStrategies; j++) {
+        for (int i = 0; i < numBuildingsPerRace; ++i) {
+            for (int j = 0; j < numAiStrategies; ++j) {
                 scenarioData.aiStrategies[j].aiBuildingSettings[i] =
                         parseAiSetting();
             }
@@ -310,8 +310,8 @@ namespace Rival {
         // Parse AI troop settings
         printSection("Parsing AI troop settings");
         printOffset();
-        for (int i = 0; i < numTroopsPerRace; i++) {
-            for (int j = 0; j < numAiStrategies; j++) {
+        for (int i = 0; i < numTroopsPerRace; ++i) {
+            for (int j = 0; j < numAiStrategies; ++j) {
                 scenarioData.aiStrategies[j].aiTroopSettings[i] =
                         parseAiSetting();
             }
@@ -640,7 +640,7 @@ namespace Rival {
             TilePlacement tile = parseTile();
 
             // Copy the tile definition to the number of tiles it describes
-            for (size_t i = 0; i < numTiles; i++) {
+            for (size_t i = 0; i < numTiles; ++i) {
                 tiles.push_back(tile);
                 tileId++;
             }
@@ -668,7 +668,7 @@ namespace Rival {
         std::vector<ObjectPlacement> objects;
         objects.reserve(numObjects);
 
-        for (unsigned int i = 0; i < numObjects; i++) {
+        for (unsigned int i = 0; i < numObjects; ++i) {
             ObjectPlacement obj = parseObject();
             objects.push_back(obj);
         }
@@ -695,7 +695,7 @@ namespace Rival {
         std::vector<BuildingPlacement> buildings;
         buildings.reserve(numBuildings);
 
-        for (unsigned int i = 0; i < numBuildings; i++) {
+        for (unsigned int i = 0; i < numBuildings; ++i) {
             BuildingPlacement bldg = parseBuilding();
             buildings.push_back(bldg);
         }
@@ -736,7 +736,7 @@ namespace Rival {
         std::vector<UnitPlacement> units;
         units.reserve(numUnits);
 
-        for (unsigned int i = 0; i < numUnits; i++) {
+        for (unsigned int i = 0; i < numUnits; ++i) {
             UnitPlacement unit = parseUnit();
             units.push_back(unit);
         }
@@ -784,7 +784,7 @@ namespace Rival {
         std::vector<ChestPlacement> chests;
         chests.reserve(numChests);
 
-        for (unsigned int i = 0; i < numChests; i++) {
+        for (unsigned int i = 0; i < numChests; ++i) {
             ChestPlacement chest = parseChest();
             chests.push_back(chest);
         }
@@ -811,7 +811,7 @@ namespace Rival {
         std::vector<InfoPointPlacement> infoPoints;
         infoPoints.reserve(numInfoPoints);
 
-        for (unsigned int i = 0; i < numInfoPoints; i++) {
+        for (unsigned int i = 0; i < numInfoPoints; ++i) {
             InfoPointPlacement infoPoint = parseInfoPoint();
             infoPoints.push_back(infoPoint);
         }
@@ -837,7 +837,7 @@ namespace Rival {
         std::vector<TrapPlacement> traps;
         traps.reserve(numTraps);
 
-        for (unsigned int i = 0; i < numTraps; i++) {
+        for (unsigned int i = 0; i < numTraps; ++i) {
             TrapPlacement trap = parseTrap();
             traps.push_back(trap);
         }
@@ -862,7 +862,7 @@ namespace Rival {
         std::vector<GoalLocation> goals;
         goals.reserve(numGoalLocations);
 
-        for (unsigned int i = 0; i < numGoalLocations; i++) {
+        for (unsigned int i = 0; i < numGoalLocations; ++i) {
             GoalLocation goal = parseGoalLocation();
             goals.push_back(goal);
         }
@@ -894,7 +894,7 @@ namespace Rival {
         std::vector<Goal> goals;
         goals.reserve(numGoals);
 
-        for (unsigned int i = 0; i < numGoals; i++) {
+        for (unsigned int i = 0; i < numGoals; ++i) {
             Goal goal = parseGoal();
             goals.push_back(goal);
         }
@@ -1063,7 +1063,7 @@ namespace Rival {
             size_t offset, size_t length) const {
 
         std::vector<char> chars(length);
-        for (size_t i = 0; i < length; i++) {
+        for (size_t i = 0; i < length; ++i) {
             chars[i] = data[offset + i];
         }
         std::string value(chars.data(), length);
@@ -1080,7 +1080,7 @@ namespace Rival {
             size_t offset, size_t length) const {
 
         std::vector<char> chars(length);
-        for (size_t i = 0; i < length; i++) {
+        for (size_t i = 0; i < length; ++i) {
             std::uint8_t c = data[offset + i];
             chars[i] = getRivalChar(c);
         }
@@ -1150,7 +1150,7 @@ namespace Rival {
         // Switch to hex
         std::cout << std::setfill('0') << std::hex;
         int col = 0;
-        for (size_t i = 0; i < n; i++) {
+        for (size_t i = 0; i < n; ++i) {
             unsigned int value = static_cast<unsigned int>(data.at(pos + i));
 
             if (value == 0) {

--- a/Open-Rival/src/Unit.cpp
+++ b/Open-Rival/src/Unit.cpp
@@ -4,16 +4,18 @@
 namespace Rival {
 
     Unit::Unit(UnitType type) :
+        deleted(false),
+        id(-1),
         type(type),
         animation(type) {}
 
     void Unit::addedToWorld(
-            int id, int player, int x, int y, Facing facing) {
-        this->id = id;
-        this->player = player;
-        this->x = x;
-        this->y = y;
-        animation.setFacing(facing);
+            int newId, int newPlayer, int newX, int newY, Facing newFacing) {
+        id = newId;
+        player = newPlayer;
+        x = newX;
+        y = newY;
+        animation.setFacing(newFacing);
     }
 
     int Unit::getCurrentSpriteIndex() const {


### PR DESCRIPTION
1) Compiler warnings are now at level 4, and a couple of fixes reflect that
2) MapBorderRenderer now allocates more than enough vertex buffers, which was preventing some maps from rendering correctly.